### PR TITLE
Potential fix for code scanning alert no. 17: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -25,8 +25,7 @@
     "nodemon": "^3.1.9",
     "socket.io": "^4.8.1",
     "twilio": "^5.5.1",
-    "uuid": "^11.1.0",
-    "express-rate-limit": "^7.5.0"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,8 @@
     "nodemon": "^3.1.9",
     "socket.io": "^4.8.1",
     "twilio": "^5.5.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",

--- a/backend/src/auctions/auctionRouter.js
+++ b/backend/src/auctions/auctionRouter.js
@@ -24,6 +24,6 @@ auctionRouter.get("/",authenticate, getAuctions)
 auctionRouter.put("/update/:id",authenticate,isOwner, updateAuction)
 auctionRouter.get('/:id',authenticate, getAuctionById)
 auctionRouter.put('/updatestatus/:id',authenticate, updateAuctionStatus)
-auctionRouter.get('/myauctions/:id',authenticate, auctionRateLimiter, getMyAuctions)
+auctionRouter.get('/myauctions/:id',auctionRateLimiter, authenticate, getMyAuctions)
 auctionRouter.delete('/delete/:id',authenticate, deleteAuction)
 export default auctionRouter

--- a/backend/src/auctions/auctionRouter.js
+++ b/backend/src/auctions/auctionRouter.js
@@ -1,5 +1,5 @@
 import express from "express";
-//import auctionController from "../controllers/auctionController.js"
+import rateLimit from "express-rate-limit";
 import { createAuction,
     getAuctions,
     isOwner,
@@ -13,11 +13,17 @@ import authenticate from "../middlewares/auth.js";
 
 const auctionRouter =  express.Router();
 
+// Define rate limiter: maximum of 100 requests per 15 minutes
+const auctionRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
+
 auctionRouter.post("/create",authenticate, createAuction)
 auctionRouter.get("/",authenticate, getAuctions)
 auctionRouter.put("/update/:id",authenticate,isOwner, updateAuction)
 auctionRouter.get('/:id',authenticate, getAuctionById)
 auctionRouter.put('/updatestatus/:id',authenticate, updateAuctionStatus)
-auctionRouter.get('/myauctions/:id',authenticate, getMyAuctions)
+auctionRouter.get('/myauctions/:id',authenticate, auctionRateLimiter, getMyAuctions)
 auctionRouter.delete('/delete/:id',authenticate, deleteAuction)
 export default auctionRouter


### PR DESCRIPTION
Potential fix for [https://github.com/Pratyay360/Kisan-Mandi/security/code-scanning/17](https://github.com/Pratyay360/Kisan-Mandi/security/code-scanning/17)

To address the issue, we will add rate limiting to the `/myauctions/:id` route using the `express-rate-limit` package. This package allows us to define a rate limiter that restricts the number of requests a user can make to the route within a specified time window. Specifically:

1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Define a rate limiter with appropriate settings (e.g., a maximum of 100 requests per 15 minutes).
4. Apply the rate limiter middleware to the `/myauctions/:id` route.

This fix ensures that the route is protected against abuse while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
