### PR TITLE
Potential fix for code scanning alert no. 38: Missing rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,8 @@
     "nodemon": "^3.1.9",
     "socket.io": "^4.8.1",
     "twilio": "^5.5.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",

--- a/backend/src/users/userRouter.js
+++ b/backend/src/users/userRouter.js
@@ -1,12 +1,20 @@
 import express from "express";
 import { createUser,loginUser,farmerInfo, vendorInfo, editUserById,acceptOrder } from "./userController.js";
 import authenticate from "../middlewares/auth.js"
+import rateLimit from "express-rate-limit";
 const userRouter = express.Router();
+
+// Rate limiter: maximum of 100 requests per 15 minutes
+const acceptOrderLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    message: "Too many requests, please try again later."
+});
 
 userRouter.post("/register", createUser )
 userRouter.post("/login", loginUser )
 userRouter.get('/farmers/:userId', authenticate, farmerInfo)
 userRouter.get('/vendors/:userId', authenticate, vendorInfo)
 userRouter.put('/update/:userId', authenticate, editUserById)
-userRouter.post('/acceptOrder', authenticate, acceptOrder)
+userRouter.post('/acceptOrder', authenticate, acceptOrderLimiter, acceptOrder)
 export default userRouter


### PR DESCRIPTION
Potential fix for [https://github.com/Pratyay360/Kisan-Mandi/security/code-scanning/38](https://github.com/Pratyay360/Kisan-Mandi/security/code-scanning/38)

To fix the issue, we will add rate limiting to the `acceptOrder` route using the `express-rate-limit` package. This middleware will restrict the number of requests a client can make to the `acceptOrder` endpoint within a specified time window. Specifically:
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Define a rate limiter with appropriate settings (e.g., a maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the `acceptOrder` route.

This fix ensures that the `acceptOrder` route is protected against abuse while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
